### PR TITLE
Add Learn section + AIMD Bootcamp sync

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -53,6 +53,11 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Sync AIMD bootcamp modules into static/learn/bootcamp
+        run: |
+          git clone --depth 1 https://github.com/NeuroTechHub/AIMD_bootcamp.git "${{ runner.temp }}/aimd-bootcamp"
+          mkdir -p static/learn/bootcamp
+          cp -R "${{ runner.temp }}/aimd-bootcamp/modules/." static/learn/bootcamp/
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ public/
 resources/_gen/
 .hugo_build.lock
 
+# Synced from external repos (see scripts/sync-bootcamp.sh)
+static/learn/bootcamp/
+
 # macOS
 .DS_Store
 .AppleDouble

--- a/content/learn/_index.md
+++ b/content/learn/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Learn"
+date: 2026-06-05
+draft: false
+description: "Hands-on learning resources from the NeuroTechHub community"
+---
+
+# Learn
+
+Hands-on materials from the NeuroTechHub community — bootcamps, tutorials, and walk-throughs you can run end-to-end in your browser.

--- a/data/learn.yaml
+++ b/data/learn.yaml
@@ -1,0 +1,6 @@
+resources:
+  - title: "AIMD Bootcamp"
+    url: "/learn/bootcamp/"
+    # image: "images/learn/aimd-bootcamp.png"  # drop a thumbnail in static/images/learn/ to enable
+    summary: "Five browser-native modules that walk the whole AI-Medical-Devices loop: camera → vision model → stimulation → phosphene simulator → decoder. Runs end-to-end, no install."
+    meta: "5 modules · runs in the browser"

--- a/scripts/sync-bootcamp.sh
+++ b/scripts/sync-bootcamp.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Pull the AIMD bootcamp modules into static/learn/bootcamp/ so `hugo server`
+# serves them locally. CI does the same step in .github/workflows/hugo.yaml.
+set -euo pipefail
+
+REPO_URL="${BOOTCAMP_REPO_URL:-https://github.com/NeuroTechHub/AIMD_bootcamp.git}"
+DEST="static/learn/bootcamp"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git clone --depth 1 "$REPO_URL" "$TMPDIR/aimd-bootcamp"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp -R "$TMPDIR/aimd-bootcamp/modules/." "$DEST/"
+
+echo "Synced bootcamp modules to $DEST"

--- a/themes/neurotech-theme/layouts/learn/list.html
+++ b/themes/neurotech-theme/layouts/learn/list.html
@@ -1,0 +1,115 @@
+{{ define "main" }}
+<section class="section" style="padding: var(--spacing-lg) 0">
+  <div class="container">
+    <div style="max-width: 760px; margin: 0 auto 2.5rem; text-align: center">
+      <p style="color: var(--text-secondary); font-size: 1.05rem; line-height: 1.6">
+        {{ .Content }}
+      </p>
+    </div>
+
+    <div class="learn-grid">
+      {{ range .Site.Data.learn.resources }}
+      <a class="learn-card" href="{{ .url | relURL }}">
+        {{ with .image }}
+        <div class="learn-card-image">
+          <img src="{{ . | relURL }}" alt="{{ $.title }}" loading="lazy" />
+        </div>
+        {{ end }}
+        <div class="learn-card-body">
+          <h3 class="learn-card-title">{{ .title }}</h3>
+          <p class="learn-card-summary">{{ .summary }}</p>
+          {{ with .meta }}
+          <p class="learn-card-meta">{{ . }}</p>
+          {{ end }}
+        </div>
+        <div class="learn-card-arrow" aria-hidden="true">&rarr;</div>
+      </a>
+      {{ end }}
+    </div>
+  </div>
+</section>
+
+<style>
+  .learn-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    max-width: 920px;
+    margin: 0 auto;
+  }
+  .learn-card {
+    display: flex;
+    align-items: stretch;
+    gap: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    border-radius: 0.75rem;
+    background: var(--color-bg-elevated, rgba(255, 255, 255, 0.04));
+    border: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+  }
+  .learn-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--color-accent, #6ea8ff);
+    background: var(--color-bg-hover, rgba(255, 255, 255, 0.06));
+  }
+  .learn-card-image {
+    flex: 0 0 180px;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    align-self: center;
+  }
+  .learn-card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .learn-card-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+  }
+  .learn-card-title {
+    margin: 0 0 0.4rem;
+    font-size: 1.15rem;
+    color: var(--text-primary, #fff);
+  }
+  .learn-card-summary {
+    margin: 0;
+    color: var(--text-secondary, #c8c8c8);
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .learn-card-meta {
+    margin: 0.6rem 0 0;
+    color: var(--color-gray, #888);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .learn-card-arrow {
+    align-self: center;
+    font-size: 1.4rem;
+    color: var(--color-accent, #6ea8ff);
+    flex: 0 0 auto;
+  }
+  @media (max-width: 640px) {
+    .learn-card {
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .learn-card-image {
+      flex: 0 0 auto;
+      width: 100%;
+      max-height: 180px;
+    }
+    .learn-card-arrow {
+      align-self: flex-end;
+    }
+  }
+</style>
+{{ end }}

--- a/themes/neurotech-theme/layouts/partials/header.html
+++ b/themes/neurotech-theme/layouts/partials/header.html
@@ -16,6 +16,7 @@
                 <div class="nav-menu" id="nav-menu">
                     <a href="{{ "/blog/" | relURL }}" class="nav-link">BLOG</a>
                     <a href="{{ "/talks/" | relURL }}" class="nav-link">EVENTS</a>
+                    <a href="{{ "/learn/" | relURL }}" class="nav-link">LEARN</a>
                     <div class="theme-toggle-switch" id="theme-toggle" aria-label="Toggle theme">
                         <div class="theme-toggle-track">
                             <div class="theme-toggle-slider"></div>


### PR DESCRIPTION
### Summary

- Adds a `LEARN` link to the top nav (between `EVENTS` and the menu end) pointing at a new `/learn/` index page.
- `/learn/` renders horizontal cards driven by `data/learn.yaml` — first (and only, for now) card is the AIMD Bootcamp.
- Pulls `NeuroTechHub/AIMD_bootcamp` `modules/` into `static/learn/bootcamp/` at build time, so the existing browser-native modules (M1–M5) ship at `neurotechhub.org/learn/bootcamp/…` without being duplicated in this repo.

### What changed

| File | Why |
|---|---|
| `themes/neurotech-theme/layouts/partials/header.html` | New `LEARN` nav link. Header is hardcoded (not `[menu.main]`-driven), so this is the only place the link belongs. |
| `content/learn/_index.md` | Hugo section frontmatter + intro copy that renders above the cards. |
| `data/learn.yaml` | Card list. Adding a future resource is one YAML entry. `image:` is optional — leave commented and the card renders text-only. |
| `themes/neurotech-theme/layouts/learn/list.html` | Section layout: iterates `Site.Data.learn.resources`, renders a horizontal card per entry. Self-contained styles, no theme-CSS changes. |
| `.github/workflows/hugo.yaml` | One `git clone --depth 1` step that copies `AIMD_bootcamp/modules/` into `static/learn/bootcamp/` before Hugo builds. |
| `scripts/sync-bootcamp.sh` | Same step for local dev: run before `hugo server` to see the bootcamp pages. |
| `.gitignore` | Ignores `static/learn/bootcamp/` — it's a sync target, never committed here. |

### URLs after merge

- `/learn/` — section index, horizontal cards
- `/learn/bootcamp/` — bootcamp's own `index.html` (the 5-step hero diagram), unmodified
- `/learn/bootcamp/M1-…html` through `M5-…html`
- `/learn/bootcamp/assets/…`, `/learn/bootcamp/_shared.css`

All bootcamp internal links are relative, so they keep working under `/learn/bootcamp/` without rewriting.

### Tradeoffs / things to know

- **Updates aren't automatic.** A push to `AIMD_bootcamp` does not rebuild this site. Trigger a build manually (Actions → Run workflow), or wire a `repository_dispatch` from `AIMD_bootcamp` later if we want auto-sync.
- **Pinning is loose.** `--depth 1` clones whatever's on `AIMD_bootcamp/main` at build time. If we ever want reproducible builds, swap for a pinned commit/tag.
- **Local dev requires a one-time `./scripts/sync-bootcamp.sh`.** The script is idempotent and the target is gitignored.
- **No thumbnail on the AIMD card yet.** Drop one at `static/images/learn/aimd-bootcamp.png` and uncomment the `image:` line in `data/learn.yaml` to enable.

### Related upstream fix

While testing locally I hit a broken OpenCV.js URL in `M1` (OpenCV pruned `docs.opencv.org/4.10.0/opencv.js` on 2026-06-04). Fixed in `AIMD_bootcamp@9f5a78d` (pinned to `4.x` symlink). No change needed in this repo.
